### PR TITLE
Add AGENTS.md with Cursor Cloud development environment instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,7 +20,7 @@ dotnet build Client/Client.fsproj
 - **Server:** `dotnet run --project Server` (default port 8963, or pass a custom port as an argument)
 - **Client:** `dotnet run --project Client` (interactive console app — requires stdin for channel name, username, password, and messages)
 
-The Client is fully interactive and cannot be driven non-interactively with `dotnet run`. For automated testing, connect directly via raw TCP sockets (e.g. Python `socket` module) and send the protocol lines: channel name, then `username:password`, then chat messages.
+The Client is interactive (reads from stdin). To test it in a headless/agent environment, run it inside a tmux session and use `tmux send-keys` to feed input line by line. Wait ~4 seconds after `dotnet run --project Client` for the F# compilation/startup before sending the first input.
 
 ### Protocol (for automated testing)
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,42 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+### Overview
+
+TCP Chat is an F# application with two console projects (Server and Client) targeting .NET 8. There are no NuGet package dependencies, no database, and no Docker — only the .NET 8 SDK is required.
+
+### Build
+
+There is no `.sln` file. Build each project individually:
+
+```sh
+dotnet build Server/Server.fsproj
+dotnet build Client/Client.fsproj
+```
+
+### Running
+
+- **Server:** `dotnet run --project Server` (default port 8963, or pass a custom port as an argument)
+- **Client:** `dotnet run --project Client` (interactive console app — requires stdin for channel name, username, password, and messages)
+
+The Client is fully interactive and cannot be driven non-interactively with `dotnet run`. For automated testing, connect directly via raw TCP sockets (e.g. Python `socket` module) and send the protocol lines: channel name, then `username:password`, then chat messages.
+
+### Protocol (for automated testing)
+
+1. Client sends channel name (one line)
+2. Client sends `username:password` (one line)
+3. Server responds with `AUTH_OK` or `AUTH_FAIL`
+4. After `AUTH_OK`, client sends chat messages (one line each); server broadcasts to all channel members
+
+### User storage
+
+User credentials are auto-persisted to `users.json` in the working directory. This file is created on first registration. Delete it to reset all accounts.
+
+### .NET SDK path
+
+The .NET 8 SDK is installed to `$HOME/.dotnet`. The PATH export is in `~/.bashrc`. If `dotnet` is not found, run:
+
+```sh
+export PATH="$HOME/.dotnet:$PATH"
+```


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds `AGENTS.md` with Cursor Cloud specific instructions for future agents to develop in this codebase.

### What's included
- Build instructions (no `.sln` file — must build each `.fsproj` individually)
- Server and Client run commands
- TCP protocol documentation for automated testing
- How to drive the interactive Client via tmux `send-keys` in headless environments
- User storage notes (`users.json` auto-created on first registration)
- .NET SDK path configuration

### Environment verification

The development environment was fully set up and verified end-to-end using the **actual F# Client binary** (`dotnet run --project Client`):

- .NET 8 SDK (8.0.420) installed
- Both Server and Client projects build successfully with zero warnings/errors
- Server starts and listens on port 8963
- Two real Client instances (Alice and Bob) connected, authenticated, exchanged messages, and disconnected with `/quit`

#### Alice connects and joins the channel
[Alice connected](https://cursor.com/agents/bc-5fc6afc2-a235-462a-b890-48ad0832e966/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Falice_connected.webp)

#### Bob connects and joins the same channel
[Bob connected](https://cursor.com/agents/bc-5fc6afc2-a235-462a-b890-48ad0832e966/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbob_connected.webp)

#### Bob sends a message to Alice
[Bob sends message](https://cursor.com/agents/bc-5fc6afc2-a235-462a-b890-48ad0832e966/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbob_sends_message.webp)

#### Alice receives Bob's message
[Alice receives message](https://cursor.com/agents/bc-5fc6afc2-a235-462a-b890-48ad0832e966/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Falice_receives_message.webp)

#### Alice replies to Bob
[Alice replies](https://cursor.com/agents/bc-5fc6afc2-a235-462a-b890-48ad0832e966/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Falice_replies.webp)

#### Bob receives Alice's reply
[Bob receives reply](https://cursor.com/agents/bc-5fc6afc2-a235-462a-b890-48ad0832e966/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbob_receives_reply.webp)

#### Bob disconnects with /quit
[Bob quits](https://cursor.com/agents/bc-5fc6afc2-a235-462a-b890-48ad0832e966/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fbob_quits.webp)

#### Alice sees Bob left
[Alice sees Bob left](https://cursor.com/agents/bc-5fc6afc2-a235-462a-b890-48ad0832e966/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Falice_sees_bob_left.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5fc6afc2-a235-462a-b890-48ad0832e966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5fc6afc2-a235-462a-b890-48ad0832e966"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

